### PR TITLE
Adopt homematicip_cloud test data

### DIFF
--- a/tests/fixtures/homematicip_cloud.json
+++ b/tests/fixtures/homematicip_cloud.json
@@ -7037,7 +7037,7 @@
             "dutyCycle": false,
             "homeId": "00000000-0000-0000-0000-000000000001",
             "id": "00000000-0000-0000-0000-000000000016",
-            "ignorableDevices": [],
+            "ignorableDeviceChannels": [],
             "label": "INTERNAL",
             "lastStatusUpdate": 1524515489257,
             "lowBat": false,
@@ -7373,7 +7373,7 @@
             "dutyCycle": false,
             "homeId": "00000000-0000-0000-0000-000000000001",
             "id": "00000000-0000-0000-0000-000000000005",
-            "ignorableDevices": [],
+            "ignorableDeviceChannels": [],
             "label": "EXTERNAL",
             "lastStatusUpdate": 1524516526498,
             "lowBat": false,
@@ -8363,7 +8363,10 @@
                 "activationInProgress": false,
                 "active": true,
                 "alarmActive": false,
-                "alarmEventDeviceId": "3014F7110000000000000007",
+                "alarmEventDeviceChannel": {
+                    "channelIndex": 1,
+                    "deviceId": "3014F7110000000000000007"
+                },
                 "alarmEventTimestamp": 1524504122047,
                 "alarmSecurityJournalEntryType": "SENSOR_EVENT",
                 "functionalGroups": [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Pull request home-assistant/core#51407 addresses the changes done in coreGreenberet/homematicip-rest-api#410 only by updating the dependency to the newer released version of it, making it aware of the new channel indexes.
However it currently fails the integration checks [as mentioned by @frenck](https://github.com/home-assistant/core/pull/51407#pullrequestreview-693447049).
It seems that the local homeassistant test suite also has a dedicated version of the test data written [here](https://github.com/coreGreenberet/homematicip-rest-api/blob/d7c1b2c231603603b543e57eff1c0bcd6fd5e268/homematicip_demo/json_data/home.json#L8598). 
So maybe we also have to manually sync these changes.


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR attributes: home-assistant/core#51407

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
